### PR TITLE
Unified Recognizer interface for all three APIs

### DIFF
--- a/src/components/api/azure/azureRecognizer.tsx
+++ b/src/components/api/azure/azureRecognizer.tsx
@@ -1,21 +1,13 @@
-import React, { useCallback, useMemo, useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
 import * as speechSDK from 'microsoft-cognitiveservices-speech-sdk';
-
-import { ControlStatus, AzureStatus, ApiStatus, PhraseList, STATUS } from '../../../react-redux&middleware/redux/typesImports';
-import { makeEventBucket } from '../../../react-redux&middleware/react-middleware/thunkMiddleware';
+import { ControlStatus, AzureStatus } from '../../../react-redux&middleware/redux/typesImports';
 import { Recognizer } from '../recognizer';
 import { TranscriptBlock } from '../../../react-redux&middleware/redux/types/TranscriptTypes';
-
-// TODO: Do we still need API status and updating API status?
-// TODO: How does event bucket thunk work? What should onTranscribed feed to the callback?
-
 export class AzureRecognizer implements Recognizer {
     /**
      * Underlying azure recognizer instance
      * Azure recognizer SDK: https://learn.microsoft.com/en-us/javascript/api/microsoft-cognitiveservices-speech-sdk/?view=azure-node-latest 
      */
-    private recognizer: speechSDK.TranslationRecognizer;
+    private recognizer: speechSDK.SpeechRecognizer;
 
     /**
      * Creates an Azure recognizer instance that listens to the default microphone
@@ -32,7 +24,7 @@ export class AzureRecognizer implements Recognizer {
             speechConfig.setProfanity(2);
 
             const audioConfig = speechSDK.AudioConfig.fromDefaultMicrophoneInput();
-            this.recognizer = new speechSDK.TranslationRecognizer(speechConfig, audioConfig);
+            this.recognizer = new speechSDK.SpeechRecognizer(speechConfig, audioConfig);
                
             let phraseList = speechSDK.PhraseListGrammar.fromRecognizer(this.recognizer);
             for (let i = 0; i < azureArgs.phrases.length; i++) {

--- a/src/components/api/azure/azureRecognizer.tsx
+++ b/src/components/api/azure/azureRecognizer.tsx
@@ -1,0 +1,135 @@
+import React, { useCallback, useMemo, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import * as speechSDK from 'microsoft-cognitiveservices-speech-sdk';
+
+import { ControlStatus, AzureStatus, ApiStatus, PhraseList, STATUS } from '../../../react-redux&middleware/redux/typesImports';
+import { makeEventBucket } from '../../../react-redux&middleware/react-middleware/thunkMiddleware';
+import { Recognizer } from '../recognizer';
+import { TranscriptBlock } from '../../../react-redux&middleware/redux/types/TranscriptTypes';
+
+// TODO: Do we still need API status and updating API status?
+// TODO: How does event bucket thunk work? What should onTranscribed feed to the callback?
+
+export class AzureRecognizer implements Recognizer {
+    /**
+     * Underlying azure recognizer instance
+     * Azure recognizer SDK: https://learn.microsoft.com/en-us/javascript/api/microsoft-cognitiveservices-speech-sdk/?view=azure-node-latest 
+     */
+    private recognizer: speechSDK.TranslationRecognizer;
+
+    /**
+     * Creates an Azure recognizer instance that listens to the default microphone
+     * and expects speech in the given language 
+     * @param audioSource Not implemented yet
+     * @param language Expected language of the speech to be transcribed
+     */
+    constructor(audioSource: any, language: string, azureArgs: AzureStatus) {
+        console.log("Azure recognizer, new recognizer being created!")
+        try {
+            const speechConfig = speechSDK.SpeechTranslationConfig.fromSubscription(azureArgs.azureKey, azureArgs.azureRegion)
+            speechConfig.speechRecognitionLanguage = language;
+            speechConfig.addTargetLanguage(language);
+            speechConfig.setProfanity(2);
+
+            const audioConfig = speechSDK.AudioConfig.fromDefaultMicrophoneInput();
+            this.recognizer = new speechSDK.TranslationRecognizer(speechConfig, audioConfig);
+               
+            let phraseList = speechSDK.PhraseListGrammar.fromRecognizer(this.recognizer);
+            for (let i = 0; i < azureArgs.phrases.length; i++) {
+                phraseList.addPhrase(azureArgs.phrases[i])
+            }
+        } catch (e : any) {
+            throw new Error(`Failed to Make Azure TranslationRecognizer, error: ${e}`);
+        }
+    }
+
+    /**
+     * Makes the Azure recognizer start transcribing speech asynchronously
+     * Throws exception if recognizer fails to start
+     */
+    start() {
+        this.recognizer.startContinuousRecognitionAsync();
+    }
+
+    /**
+     * Makes the Azure recognizer stop transcribing speech asynchronously
+     * Throws exception if recognizer fails to stop
+     */
+    stop() {
+        this.recognizer.stopContinuousRecognitionAsync();
+    }
+
+    /**
+     * Subscribe a callback function to the transcript update event, which is usually triggered
+     * when the recognizer has processed more speech
+     * @param callback A callback function called with the latest transcript when the event is triggered
+     */
+    onTranscribed(callback: (newFinalBlocks: Array<TranscriptBlock>, newInProgressBlock: TranscriptBlock) => void) {
+        // "recognizing" event signals that the in-progress block has been updated
+        // event.result.text is new in-progress block's text
+        try {
+            this.recognizer.recognizing = (sender, event) => {
+                const newInProgressBlock = new TranscriptBlock;
+                newInProgressBlock.text = event.result.text;
+                callback([], newInProgressBlock);
+            }
+            this.recognizer.recognized = (sender, event) => {
+                if (event.result.reason == speechSDK.ResultReason.NoMatch) {
+                    // Spurious "recognized" event can be triggered with empty transcript text
+                    // Possibly an Azure bug
+                    return; 
+                }
+                // "recognized" signals that the current in-progress block is finalized
+                // event.result.text is the finalized block's text
+                // In-progress block should also be cleared
+                const newFinalBlock = new TranscriptBlock;
+                newFinalBlock.text = event.result.text;
+                const newInProgressBlock = new TranscriptBlock;
+                callback([newFinalBlock], newInProgressBlock);
+            }
+        } catch (e) {
+            throw new Error(`Could not add callback to Azure recognizer, error: ${e}`)
+        }
+    }
+
+    /**
+     * Subscribe a callback function to the error event, which is triggered
+     * when the recognizer has encountered an error that it cannot handle
+     * @param callback A callback function called with the error object when the event is triggered
+     */
+    onError(callback: (e: Error) => void) {
+        // Do nothing, Azure does not have an error event
+    }
+
+    /**
+     * Add Domain phrases to the recognizer 
+     * @param newPhrases New phrases to be added
+     */
+    addPhrases(newPhrases: string[]) {
+        let phraseList = speechSDK.PhraseListGrammar.fromRecognizer(this.recognizer);
+        phraseList.addPhrases(newPhrases);
+    }
+}
+
+
+/**
+ * Used in Azuredropdown.tsx; return a TranslationRecognizer is no error
+ * 
+ * @param control type of ControlStatus
+ * @param azure type of AzureStatus
+ * @returns a TranslationRecognizer
+ */
+export const testAzureTranslRecog = async (control: ControlStatus, azure: AzureStatus) => new Promise<void>((resolve, reject) => {
+    try {
+        const recognizer: Recognizer = new AzureRecognizer(null, control.speechLanguage.CountryCode, azure);
+        recognizer.onError((e) => {
+            console.log(`CANCELED: Reason=${e.message}, Did you update the subscription info?`);
+            reject();
+        })
+        recognizer.start()
+        resolve();
+    } catch (e) {
+      reject();
+    };
+});
+

--- a/src/components/api/azure/azureTranslRecog.tsx
+++ b/src/components/api/azure/azureTranslRecog.tsx
@@ -100,7 +100,7 @@ export const useAzureTranslRecog = (recognizer : speechSDK.TranslationRecognizer
          // Signals that the current paragraph is not yet over, but more transcript is available
          // event.result.text is the in-progress transcript of the current paragraph
          // Newer event.result.text is not guaranteed to contain older event.result.text as prefix, e.g. "Five bites" -> "Five bytes of memory"
-         console.log(89);
+         console.log("Azure, incomplete transcript", e.result);
          const eventBucketThunk = makeEventBucket({ stream: 'azure', value: { confidence: -1, transcript: e.result.text }});
          dispatch(eventBucketThunk); 
          // TODO: Documentation for makeEventBucket and dispatching thunk
@@ -108,7 +108,7 @@ export const useAzureTranslRecog = (recognizer : speechSDK.TranslationRecognizer
       recognizer.recognized = (s, e) => {
          // Signals that the current paragraph is over.
          // event.result.text is the finalized transcript of the current paragraph
-         console.log(101, e.result.text);
+         console.log("Azure, finalized transcript", e.result);
          dispatch({ type: 'transcript/azure/recognized', payload: {newTranscript: e.result.text} }); // TODO: modify, think over how this would affect the Stream
       };
       recognizer.sessionStarted = (s, e) => {

--- a/src/components/api/recogComponent.tsx
+++ b/src/components/api/recogComponent.tsx
@@ -59,6 +59,7 @@ export const RecogComponent: React.FC = (props) => {
    })
 
    // if else for whisper transcript, apiStatus for 4=whisper and control status for listening
-   const { transcript, recogHandler } = useRecognition(sRecog, apiStatus, controlStatus, azureStatus);
+   const transcript = useRecognition(sRecog, apiStatus, controlStatus, azureStatus);
+   console.log("Recog component received new transcript: ", transcript)
    return STTRenderer(transcript);
 };

--- a/src/components/api/recognizer.tsx
+++ b/src/components/api/recognizer.tsx
@@ -27,6 +27,42 @@
  */
 
 /**
+ * Webspeech recognizer maintains an array of blocks, each containing a transcript string, a confidence value,
+ * and a final / in-progress bit. 
+ * 
+ * Whenever the array is updated, a recognized event is triggered. A recognized event is also triggered when the recognizer
+ * Receives the stop signal, as the in-progress blocks are forced to be finalized before stopping the recognizer.
+ * 
+ * If we conceptualize it as an array of final blocks and an array of in progress blocks, then they obey
+ * these invariants:
+ * 
+ * 1. The array of final blocks is append-only, array_old is a prefix of array_new
+ * 2. The array of in-progress blocks can only contain 0-2 blocks, and is not append-only
+ * 3. Both arrays are empty immediately after the recognizer starts
+ * 4. The in-progress array is empty in the last array update event immediately before the recognizer stops
+ */
+
+/**
+ * Azure recognizer maintains a single block that contains a transcript string, and a final / in progress bit
+ * 
+ * Whenever the block is updated but still in-progress, a recognizing event is triggered. Whenever the block
+ * becomes final, a recognized event is triggered. 
+ * 
+ * A recognized event is also triggered when the stop signal is received, as the block is forced
+ * to be finalized before stopping the recognizer. This is followed by a spurious recognized event
+ * With empty string transcript and reason value of 0 meaning "unable to recognize speech"
+ * 
+ * Again we can conceptualize it as an array of final blocks and a single in-progress block.
+ * Whenever we receive a "recognized" event we append the finalized block to the final array, and empty in-progress block
+ * Whenever we receive a "recognizing" event, we update the in-progress block
+ * From this perspective, they obey these invariants:
+ * 
+ * 1. The array of final blocks is append-only
+ * 2. The in-progress block is not append-only, it can be cleared
+ *  * 4. The in-progress block is empty in the last recognized event immediately before the recognizer stops
+ */
+
+/**
  * The transcript of a continuous segment of speech, represented by one or more 
  * Finalized transcript blocks followed by an in-progress block.
  * 

--- a/src/components/api/recognizer.tsx
+++ b/src/components/api/recognizer.tsx
@@ -1,68 +1,27 @@
+import { TranscriptBlock } from "../../react-redux&middleware/redux/types/TranscriptTypes";
 /**
- * A recognizer is an abstract object that has the following functions
+ * Abstractly, a recognizer is an object that has the following functions
  * 
  * void start()
- *      Makes the recognizer starts transcribing speech from given audio source
+ *      Makes the recognizer starts transcribing speech, if it has not already started
  * 
  * void stop()
- *      Makes the recognizer stops transcribing speech
+ *      Makes the recognizer stops transcribing speech, if it has not already stopped
  * 
- * void onTranscribed(transcript update -> void function Callback)
- *      Subscribes a callback function to the transcript update event, which is triggered
- *      when the transcript has been updated due to more speech being transcribed
+ * void onTranscribed((list of new final blocks, new WIP block) -> void Callback)
+ *      Subscribes a callback function to be called whenever the transcript is updated -
+ *      when more speech has been transcribed, or some transcript has been finalized
  * 
- * void onError(error -> void function Callback)
+ * void onError(error -> void Callback)
  *      Subscribes a callback function to the recognizer error event, which is triggered
  *      when the recognizer encouters an error (that may or may not be fatal)
  * 
- * (Should there be an event handler for unexpected stop like one caused by fatal error?)
+ * In the future, we want all recognizer to be constructed by a function like such:
  * 
- * Further, it should be instantiated by the following function:
- * 
- * Recognizer createRecognizer(enum? audioSource, string? language)
- *      Constructor that creates a recognizer instance ready to be started using the given args
- *      (Are args necessary? Should CreateRecognizer directly fetch from Redux store?)
- *      (What types are appropriate for representing audio source and language?)
+ * Recognizer createRecognizer(audioSource, language)
+ *      Where audioSource could be either microphone, stream, or audio file
+ *      (By Convert all of them to a stream format of some sort first?)
  */
-
-import { TranscriptBlock } from "../../react-redux&middleware/redux/types/TranscriptTypes";
-
-/**
- * Webspeech recognizer maintains an array of blocks, each containing a transcript string, a confidence value,
- * and a final / in-progress bit. 
- * 
- * Whenever the array is updated, a recognized event is triggered. A recognized event is also triggered when the recognizer
- * Receives the stop signal, as the in-progress blocks are forced to be finalized before stopping the recognizer.
- * 
- * If we conceptualize it as an array of final blocks and an array of in progress blocks, then they obey
- * these invariants:
- * 
- * 1. The array of final blocks is append-only, array_old is a prefix of array_new
- * 2. The array of in-progress blocks can only contain 0-2 blocks, and is not append-only
- * 3. Both arrays are empty immediately after the recognizer starts
- * 4. The in-progress array is empty in the last array update event immediately before the recognizer stops
- */
-
-/**
- * Azure recognizer maintains a single block that contains a transcript string, and a final / in progress bit
- * 
- * Whenever the block is updated but still in-progress, a recognizing event is triggered. Whenever the block
- * becomes final, a recognized event is triggered. 
- * 
- * A recognized event is also triggered when the stop signal is received, as the block is forced
- * to be finalized before stopping the recognizer. This is followed by a spurious recognized event
- * With empty string transcript and reason value of 0 meaning "unable to recognize speech"
- * 
- * Again we can conceptualize it as an array of final blocks and a single in-progress block.
- * Whenever we receive a "recognized" event we append the finalized block to the final array, and empty in-progress block
- * Whenever we receive a "recognizing" event, we update the in-progress block
- * From this perspective, they obey these invariants:
- * 
- * 1. The array of final blocks is append-only
- * 2. The in-progress block is not append-only, it can be cleared
- *  * 4. The in-progress block is empty in the last recognized event immediately before the recognizer stops
- */
-
 
 /**
  * Abstract recognizer interface that describes an async speech recognizer that converts

--- a/src/components/api/recognizer.tsx
+++ b/src/components/api/recognizer.tsx
@@ -7,10 +7,9 @@
  * void stop()
  *      Makes the recognizer stops transcribing speech
  * 
- * void onTranscribed(transcript -> void function Callback)
+ * void onTranscribed(transcript update -> void function Callback)
  *      Subscribes a callback function to the transcript update event, which is triggered
  *      when the transcript has been updated due to more speech being transcribed
- *      (What type is appropriate for representing transcript? plain string?)
  * 
  * void onError(error -> void function Callback)
  *      Subscribes a callback function to the recognizer error event, which is triggered
@@ -25,6 +24,8 @@
  *      (Are args necessary? Should CreateRecognizer directly fetch from Redux store?)
  *      (What types are appropriate for representing audio source and language?)
  */
+
+import { TranscriptBlock } from "../../react-redux&middleware/redux/types/TranscriptTypes";
 
 /**
  * Webspeech recognizer maintains an array of blocks, each containing a transcript string, a confidence value,
@@ -62,20 +63,6 @@
  *  * 4. The in-progress block is empty in the last recognized event immediately before the recognizer stops
  */
 
-/**
- * The transcript of a continuous segment of speech, represented by one or more 
- * Finalized transcript blocks followed by an in-progress block.
- * 
- * Each block is the transcript of a sub-segment of speech, in chronological order, and the
- * Complete transcript is the concatenation of all blocks:
- * 
- * final_0 -> final_1 ->...-> final_n -> in_progress
- * 
- */
-export class Transcript {
-    finalBlocks: Array<string> = [];
-    inProgressBlock: string = "";
-}
 
 /**
  * Abstract recognizer interface that describes an async speech recognizer that converts
@@ -101,9 +88,9 @@ export interface Recognizer{
     /**
      * Subscribe a callback function to the transcript update event, which is usually triggered
      * when the recognizer has processed more speech
-     * @param callback A callback function called with the latest transcript when the event is triggered
+     * @param callback A callback function called with newly finalized blocks and new in-progress block
      */
-    onTranscribed(callback: (transcript: Transcript) => void);
+    onTranscribed(callback: (newFinalBlocks: Array<TranscriptBlock>, newInProgressBlock: TranscriptBlock) => void);
 
     /**
      * Subscribe a callback function to the error event, which is triggered

--- a/src/components/api/returnAPI.tsx
+++ b/src/components/api/returnAPI.tsx
@@ -118,36 +118,6 @@ const getRecognizer = (currentApi: number, control: ControlStatus, azure: AzureS
 }
 
 /**
- * Connect the recognizer to the event handler
- * @param currentApi 
- * @param recognizer 
- * @returns Promsie<ScribeHandler>
- */
-const runRecognition = (currentApi: number, recognizer : ScribeRecognizer, dispatch : React.Dispatch<any>) => new Promise<ScribeHandler>((resolve, reject) => {
-   if (currentApi === API.WEBSPEECH) { // webspeech recognition event controller
-      useWebSpeechRecog(recognizer as SpeechRecognition, dispatch)
-         .then(() => {
-            resolve(makeWebSpeechHandler(recognizer));            
-         })
-         .catch((error_str : string) => {
-            reject(error_str);
-         });
-   } else if (currentApi === API.AZURE_TRANSLATION) { // azure recognition event controller
-      useAzureTranslRecog(recognizer as sdk.TranslationRecognizer, dispatch)
-         .then(() => {
-            console.log(163, 'Azure recog initiated');
-            resolve(makeAzureTranslHandler(recognizer));
-         })
-         .catch((error_str : string) => {
-            console.log(167, error_str);
-            reject(error_str);
-         });
-   } else {
-      reject(`Unexpcted API_CODE: ${currentApi}`);
-   }
-});
-
-/**
  * Make a callback function that updates the Redux transcript using new final blocks and new
  * in-progress block
  * 

--- a/src/components/api/returnAPI.tsx
+++ b/src/components/api/returnAPI.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState, useMemo, useCallback } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { batch, useDispatch, useSelector } from 'react-redux';
 import { 
    DisplayStatus, AzureStatus, ControlStatus, 
-   ApiStatus, SRecognition, Transcript,
+   ApiStatus, SRecognition,
    ScribeRecognizer, ScribeHandler, } from '../../react-redux&middleware/redux/typesImports';
 import { API, ApiType, STATUS, StatusType } from '../../react-redux&middleware/redux/typesImports';
 import { RootState } from '../../store';
@@ -13,6 +13,11 @@ import { getAzureTranslRecog, testAzureTranslRecog, useAzureTranslRecog } from '
 import { loadTokenizer } from '../../ml/bert_tokenizer';
 
 import { intent_inference } from '../../ml/inference';
+import { TranscriptReducer } from '../../react-redux&middleware/redux/reducers/transcriptReducers';
+import { Recognizer } from './recognizer';
+import { AzureRecognizer } from './azure/azureRecognizer';
+import { TranscriptBlock } from '../../react-redux&middleware/redux/types/TranscriptTypes';
+import { Dispatch } from 'redux';
 
 
 // controls what api to send and what to do when error handling.
@@ -77,62 +82,6 @@ const makeWebSpeechHandler = (recognition : ScribeRecognizer) : ScribeHandler =>
    }
    return handler;
 }
-/**
- * 
- * @param recognizer
- * @returns 
- */
-const makeAzureTranslHandler = (recognizer : ScribeRecognizer) : ScribeHandler => {
-   const handler : ScribeHandler = (action) => {
-      try {
-         recognizer = recognizer as sdk.TranslationRecognizer;
-         switch (action.type) {
-            case 'STOP':
-               recognizer!.stopContinuousRecognitionAsync();
-               break;
-            case 'START':
-               recognizer!.startContinuousRecognitionAsync()
-               break;
-            case 'ABORT':
-               recognizer!.close()
-               break;
-            case 'CHANGE_LANGUAGE':
-               recognizer!.addTargetLanguage(action.payload!)
-               break;
-            case 'CHANGE_PHRASE':
-               // add phraseList
-               let phraseList = sdk.PhraseListGrammar.fromRecognizer(recognizer);
-               for (let i = 0; i < action.payload!.length; i++) {
-                  phraseList.addPhrase(action.payload![i])
-               }
-               break;
-            default:
-               return "poggers";
-         }
-      } catch (e : any) {
-         console.log(`While trying to ${action.type} Azure, an error occurred`, e);
-      }
-   }
-   return handler;
-}
-// export const testRecognition = (control: ControlStatus, azure: AzureStatus, currentApi: number) => {
-//     if (currentApi == 0) { // webspeech
-//         // return getWebSpeechRecognition();
-//         throw new Error("Not implemented");
-//     } else if (currentApi == 1) { // azure translation
-//         testAzureTranslRecog(control, azure).then((result) => {
-//             console.log(result);
-//         });
-
-//         // getAzureTranslRecog(control, azure).then((recognizer : sdk.TranslationRecognizer) => {
-//         //     testAzureTranslRecog(recognizer);
-//         // }, (error_str : string) => {
-//         //     reject(error_str);
-//         // });
-//     } else {
-//         throw(`Unexpcted API: ${currentApi}`);
-//     }
-// }
 
 const getRecognition = (currentApi: number, control: ControlStatus, azure: AzureStatus) => {
    // https://reactjs.org/docs/hooks-reference.html#usecallback
@@ -153,9 +102,20 @@ const getRecognition = (currentApi: number, control: ControlStatus, azure: Azure
    }
 }
 
-// else if (currentApi === API.WHISPER){
+const getRecognizer = (currentApi: number, control: ControlStatus, azure: AzureStatus): Recognizer => {
 
-// }
+   if (currentApi === API.WEBSPEECH) {
+      // TODO
+      throw new Error("Not implemented");
+   } else if (currentApi === API.AZURE_TRANSLATION) {
+      return new AzureRecognizer(null, control.speechLanguage.CountryCode, azure)
+   } 
+   else if (currentApi === API.AZURE_CONVERSATION) {
+      throw new Error("Not implemented");
+   } else {
+      throw new Error(`Unexpcted API_CODE: ${currentApi}`);
+   }
+}
 
 /**
  * Connect the recognizer to the event handler
@@ -188,6 +148,25 @@ const runRecognition = (currentApi: number, recognizer : ScribeRecognizer, dispa
 });
 
 /**
+ * Make a callback function that updates the Redux transcript using new final blocks and new
+ * in-progress block
+ * 
+ * We have to do things in this roundabout way to have access to dispatch in a callback function,
+ * see https://stackoverflow.com/questions/59456816/how-to-call-usedispatch-in-a-callback
+ * @param dispatch A Redux dispatch function
+ */
+const updateTranscript = (dispatch: Dispatch) => (newFinalBlocks: Array<TranscriptBlock>, newInProgressBlock: TranscriptBlock): void => {
+   console.log(`Updating transcript using these blocks: `, newFinalBlocks, newInProgressBlock)
+   // batch makes these dispatches only cause one re-rendering
+   batch(() => {
+      for (const block of newFinalBlocks) {
+         dispatch({type: "transcript/new_final_block", payload: block});
+      }
+      dispatch({type: 'transcript/update_in_progress_block', payload: newInProgressBlock});
+   })
+}
+
+/**
  * Called when the compoenent rerender.
  * Check current state, setup/start the recognizer if needed.
  * Always return the full transcripts, a function to reset the transcript,
@@ -213,108 +192,82 @@ const runRecognition = (currentApi: number, recognizer : ScribeRecognizer, dispa
 export const useRecognition = (sRecog : SRecognition, api : ApiStatus, control : ControlStatus, azure : AzureStatus) => {
 
 
-   const [recogHandler, setRecogHandler] = useState<ScribeHandler>();
+   const [recognizer, setRecognizer] = useState<Recognizer>();
    // TODO: Add a reset button to utitlize resetTranscript
    // const [resetTranscript, setResetTranscript] = useState<() => string>(() => () => dispatch('RESET_TRANSCRIPT'));
    const [lastChangeApiTime, setLastChangeApiTime] = useState<number>(Date.now());
    const dispatch = useDispatch();
 
-
-   // change recognizer, if api changed
+   // Change recognizer, if api changed
    // TODO: currently we store the recognizer to redux, but never use it.
    useEffect(() => {
-      if (api.currentApi !== API.WHISPER) {
-         // stop recognizer
-         if (recogHandler) recogHandler({type: 'STOP'});
-         console.log(214,);
-
-         getRecognition(api.currentApi, control, azure)
-            .then((recog : ScribeRecognizer) => {
-               runRecognition(api.currentApi, recog, dispatch)
-                  .then((handler : ScribeHandler) => {
-                     setRecogHandler(() => handler);
-
-                     let copy_sRecog = Object.assign({}, sRecog);
-                     copy_sRecog.recognizer = recog;
-                     copy_sRecog.status = STATUS.TRANSCRIBING;
-
-                     // // change handler
-                     // console.log('recog changed', (sRecog.status === STATUS.NULL), (sRecog.status === STATUS.AVAILABLE), (control.listening));
-                     if (control.listening) {
-                        console.log(259, 'start recognition');
-                        handler({type: 'START'}); // start recognition
-                        copy_sRecog.status = STATUS.TRANSCRIBING;
-                     }
-                     
-                     dispatch({ type: 'sRecog/set_recog', payload: copy_sRecog }); // only dispatch if it is fullfilled
-                  })
-                  .catch((error_str : string) => {
-                     console.log(error_str);
-                  });
-            })
-            .catch((error_str : string) => {
-               console.log(error_str);
-            });
-      } else if (api.currentApi === API.WHISPER) {
-         return; // do nothing becuase Whisper is using iframe
+      // Stop existing recognizer
+      if (recognizer) recognizer.stop();
+      try{
+         // Create new recognizer, and subscribe to its events
+         let newRecognizer = getRecognizer(api.currentApi, control, azure);
+         newRecognizer.onTranscribed(updateTranscript(dispatch));
+         setRecognizer(newRecognizer)
+      } catch (e) {
+         console.log("UseRecognition, failed to get new recognizer: ", e);
       }
+      // Start new recognizer if necessary
+      if (control.listening) recognizer?.start()
    }, [api.currentApi]);
-   // TODO: Fix useEffect dependency arrays. Adding recogHandler to the array causes DOM to crash.
-   // control recognizer, if listening changed
+
+   // Start / stop recognizer, if listening toggled
    useEffect(() => {
-      if (!recogHandler) { // whipser won't have recogHandler
+      if (!recognizer) { // whipser won't have recogHandler
          return;
       }
       if (control.listening) {
-         console.log("Sending start signal to recognizer using handler")
-         recogHandler({type: 'START'});
+         console.log("UseRecognition, sending start signal to recognizer")
+         recognizer.start();
       } else if (!control.listening) {
-         console.log("Sending stop signal to recognizer using handler")
-         recogHandler({type: 'STOP'}); 
+         console.log("UseRecognition, sending stop signal to recognizer")
+         recognizer.stop();
       }
    }, [control.listening]);
+
    // Webspeech recognizer stops itself after not detecting speech for a while, needs to be restarted
    // restart recognizer, if status not ERROR
+   // useEffect(() => {
+   //    if (!recogHandler) { // whipser won't have recogHandler
+   //       return;
+   //    }
+   //    // console.log('change recog status: ', sRecog.status);
+   //    if (sRecog.status === STATUS.ENDED) {
+   //       const curTime = Date.now();
+   //       const timeSinceStart = curTime - lastChangeApiTime;
+   //       // console.log(curTime, timeSinceStart);
+   //       if (timeSinceStart > 1000 && control.listening) {
+   //          // console.log(timeSinceStart, control.listening);
+   //          if (recogHandler) recogHandler({type: 'START'});
+   //          setLastChangeApiTime(curTime);
+   //       }
+   //    } else if (sRecog.status === STATUS.ERROR) {
+   //       if (recogHandler) recogHandler({type: 'STOP'});
+   //    }
+   // }, [sRecog.status]);
+
+   // Update domain phrases for azure recognizer
    useEffect(() => {
-      if (!recogHandler) { // whipser won't have recogHandler
-         return;
-      }
-      // console.log('change recog status: ', sRecog.status);
-      if (sRecog.status === STATUS.ENDED) {
-         const curTime = Date.now();
-         const timeSinceStart = curTime - lastChangeApiTime;
-         // console.log(curTime, timeSinceStart);
-         if (timeSinceStart > 1000 && control.listening) {
-            // console.log(timeSinceStart, control.listening);
-            if (recogHandler) recogHandler({type: 'START'});
-            setLastChangeApiTime(curTime);
-         }
-      } else if (sRecog.status === STATUS.ERROR) {
-         if (recogHandler) recogHandler({type: 'STOP'});
-      }
-   }, [sRecog.status]);
-   // add phrases
-   useEffect(() => {
-      console.log(295, azure.phrases);
-      if (api.currentApi === API.AZURE_TRANSLATION) {
-         if (recogHandler) recogHandler({type: 'CHANGE_PHRASE', payload: azure.phrases});
+      console.log("UseRecognition, changing azure phrases", azure.phrases);
+      if (api.currentApi === API.AZURE_TRANSLATION && recognizer) {
+         (recognizer as AzureRecognizer).addPhrases(azure.phrases);
       }
    }, [azure.phrases]);
 
-
-
    // TODO: whisper's transcript is not in redux store but only in sessionStorage at the moment.
    let transcript : string = useSelector((state: RootState) => {
-      const fullTranscript : string = state.TranscriptReducer.previousTranscript[0] 
-                                       + ' ' + state.TranscriptReducer.currentTranscript[0];
-      return fullTranscript;
+      return state.TranscriptReducer.transcripts[0].toString()
    });
    if (api.currentApi === API.WHISPER) { 
       // TODO: inefficient to get it from sessionStorage everytime
       // TODO: add whisper_transcript to redux store after integrating "whisper" folder (containing stream.js) into ScribeAR
       transcript = sessionStorage.getItem('whisper_transcript') || '';
-      return { transcript, recogHandler };
+      return transcript;
    }
 
-   return { transcript, recogHandler };
+   return transcript;
 }

--- a/src/components/api/returnAPI.tsx
+++ b/src/components/api/returnAPI.tsx
@@ -266,8 +266,10 @@ export const useRecognition = (sRecog : SRecognition, api : ApiStatus, control :
          return;
       }
       if (control.listening) {
+         console.log("Sending start signal to recognizer using handler")
          recogHandler({type: 'START'});
       } else if (!control.listening) {
+         console.log("Sending stop signal to recognizer using handler")
          recogHandler({type: 'STOP'}); 
       }
    }, [control.listening]);

--- a/src/components/api/returnAPI.tsx
+++ b/src/components/api/returnAPI.tsx
@@ -18,6 +18,7 @@ import { Recognizer } from './recognizer';
 import { AzureRecognizer } from './azure/azureRecognizer';
 import { TranscriptBlock } from '../../react-redux&middleware/redux/types/TranscriptTypes';
 import { Dispatch } from 'redux';
+import { WebSpeechRecognizer } from './web-speech/webSpeechRecognizer';
 
 
 // controls what api to send and what to do when error handling.
@@ -105,10 +106,9 @@ const getRecognition = (currentApi: number, control: ControlStatus, azure: Azure
 const getRecognizer = (currentApi: number, control: ControlStatus, azure: AzureStatus): Recognizer => {
 
    if (currentApi === API.WEBSPEECH) {
-      // TODO
-      throw new Error("Not implemented");
+      return new WebSpeechRecognizer(null, control.speechLanguage.CountryCode);
    } else if (currentApi === API.AZURE_TRANSLATION) {
-      return new AzureRecognizer(null, control.speechLanguage.CountryCode, azure)
+      return new AzureRecognizer(null, control.speechLanguage.CountryCode, azure);
    } 
    else if (currentApi === API.AZURE_CONVERSATION) {
       throw new Error("Not implemented");
@@ -171,6 +171,7 @@ export const useRecognition = (sRecog : SRecognition, api : ApiStatus, control :
    // Change recognizer, if api changed
    // TODO: currently we store the recognizer to redux, but never use it.
    useEffect(() => {
+      console.log("UseRecognition, switching to new recognizer: ", api.currentApi);
       // Stop existing recognizer
       if (recognizer) recognizer.stop();
       try{

--- a/src/components/api/web-speech/webSpeechRecognizer.tsx
+++ b/src/components/api/web-speech/webSpeechRecognizer.tsx
@@ -1,0 +1,122 @@
+import { Recognizer } from '../recognizer';
+import { TranscriptBlock } from '../../../react-redux&middleware/redux/types/TranscriptTypes';
+
+export class WebSpeechRecognizer implements Recognizer {
+    /**
+     * Underlying Web Speech recognizer instance
+     * Built-in to HTML 5, see documentation here: https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API 
+     */
+    private recognizer: SpeechRecognition;
+    /**
+     * Number of final blocks in the recognizer's last event
+     * Used to only return new final blocks
+     */
+    private prevFinalBlockNum: number = 0;
+    /**
+     * Whether the recognizer should be stopped right now
+     * Used to restart recognizer after it self-stops due to inactivity
+     */
+    private shouldStop: boolean = true;
+
+    /**
+     * Creates an Web Speech recognizer instance that listens to the default microphone
+     * and expects speech in the given language 
+     * @param audioSource Not implemented yet
+     * @param language Expected language of the speech to be transcribed
+     */
+    constructor(audioSource: any, language: string) {
+        console.log("Web Speech recognizer, new recognizer being created!")
+        if (!window || !(window as any).webkitSpeechRecognition) {
+            throw new Error('Your browser does not support web speech recognition');
+        }
+        try {
+            this.recognizer = new (window as any).webkitSpeechRecognition();
+            this.recognizer.continuous = true;
+            this.recognizer.interimResults = true;
+            this.recognizer.lang = language;
+
+            this.recognizer.onend = (ev) => {
+                console.log(ev);
+                if (!this.shouldStop) this.start();
+            }
+        } catch (e) {
+            const error_str : string = `Failed to Make WebSpeech SpeechRecognition, error: ${e}`;
+            throw new Error(error_str);
+        }
+    }
+
+    /**
+     * Makes the Web Speech recognizer start transcribing speech asynchronously
+     * Throws exception if recognizer fails to start
+     */
+    start() {
+        this.shouldStop = false;
+        this.prevFinalBlockNum = 0; // Webspeech clears all final blocks when restarting
+        this.recognizer.start();
+    }
+
+    /**
+     * Makes the Web Speech recognizer stop transcribing speech asynchronously
+     * Throws exception if recognizer fails to stop
+     */
+    stop() {
+        this.shouldStop = true;
+        this.recognizer.stop();
+    }
+
+    /**
+     * Subscribe a callback function to the transcript update event, which is usually triggered
+     * when the recognizer has processed more speech
+     * @param callback A callback function called with updates to the transcript when the event is triggered
+     */
+    onTranscribed(callback: (newFinalBlocks: Array<TranscriptBlock>, newInProgressBlock: TranscriptBlock) => void) {
+        try {
+            this.recognizer.onresult = (event) => {
+                // Find how many final blocks the new result has
+                let finalBlockNum = 0;
+                for (finalBlockNum = this.prevFinalBlockNum;
+                    finalBlockNum < event.results.length && event.results[finalBlockNum].isFinal;
+                    finalBlockNum++) {}
+
+                let newFinalBlocks = Array<TranscriptBlock>();
+                let newInProgressBlock = new TranscriptBlock;
+                // Gather all new final blocks
+                for (let i = this.prevFinalBlockNum; i < finalBlockNum; i++) {
+                    const result = event.results[i];
+                    let block = new TranscriptBlock;
+                    // Each result could have multiple alterantive transcription, arbitrarily choose first one
+                    block.text = result[0].transcript;
+                    newFinalBlocks.push(block);
+                }
+                // Concat all new in-progress blocks
+                for (let i = finalBlockNum; i < event.results.length; i++) {
+                    const result = event.results[i];
+                    newInProgressBlock.text += result[0].transcript;
+                }
+                // Update number of seen final blocks
+                this.prevFinalBlockNum = finalBlockNum;
+
+                callback(newFinalBlocks, newInProgressBlock);
+            }
+        } catch (e) {
+            throw new Error(`Could not add callback to Web Speech recognizer, error: ${e}`)
+        }
+    }
+
+    /**
+     * Subscribe a callback function to the error event, which is triggered
+     * when the recognizer has encountered an error that it cannot handle
+     * @param callback A callback function called with the error object when the event is triggered
+     */
+    onError(callback: (e: Error) => void) {
+        // Signals that the recognizer has encountered an error of some kind
+        this.recognizer.onerror = (ev) => {
+            if (ev.error == 'no-speech') {
+                return;
+            }
+            console.log(`WebSpeech on error, event: ${ev}`);
+            callback(new Error(ev.message))
+        }
+    }
+
+}

--- a/src/components/navbars/topbar/api/pickApi.tsx
+++ b/src/components/navbars/topbar/api/pickApi.tsx
@@ -91,7 +91,7 @@ export default function PickApi(props) {
    const switchToAzure = async () => {
       dispatch({type: 'FLIP_RECORDING', payload: controlStatus});
       let copyStatus = Object.assign({}, apiStatus);
-      testAzureTranslRecog(controlStatus, azureStatus).then(recognizer => { 
+      testAzureTranslRecog(controlStatus, azureStatus).then(() => { 
          // fullfill (test good)
          localStorage.setItem("azureStatus", JSON.stringify(azureStatus));
          

--- a/src/components/navbars/topbar/transcriptDownload.tsx
+++ b/src/components/navbars/topbar/transcriptDownload.tsx
@@ -1,9 +1,10 @@
 import { FileDownloadIcon, ThemeProvider, IconButton, Tooltip  } from '../../../muiImports';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../../../store';
-import { ControlStatus, Transcript } from '../../../react-redux&middleware/redux/typesImports';
+import { ControlStatus } from '../../../react-redux&middleware/redux/typesImports';
 import Theme from '../../theme'
 import * as React from 'react';
+import { MultiSpeakerTranscript } from '../../../react-redux&middleware/redux/types/TranscriptTypes';
 
 export default function TranscriptDownload() {
   const dispatch = useDispatch();
@@ -13,12 +14,12 @@ export default function TranscriptDownload() {
   });
 
   let transcriptStatus = useSelector((state: RootState) => {
-    return state.TranscriptReducer as Transcript;
+    return state.TranscriptReducer as MultiSpeakerTranscript;
   });
 
 
   const handleClick = (event: React.MouseEvent) => {
-    let text = transcriptStatus.previousTranscript[0] + transcriptStatus.currentTranscript[0];
+    let text = transcriptStatus.transcripts[0].toString();
     console.log("transcript download", text);
     const blob = new Blob([text], { type: 'text/plain' });
     const url = window.URL.createObjectURL(blob);

--- a/src/react-redux&middleware/redux/reducers/transcriptReducers.tsx
+++ b/src/react-redux&middleware/redux/reducers/transcriptReducers.tsx
@@ -18,10 +18,12 @@ export const TranscriptReducer = (state = new MultiSpeakerTranscript(), action :
    console.log("Transcript Reducer, receiving dispatch", action);
    switch (action.type) {
       case 'transcript/new_final_block':
+         // Append a new final block to the transcript
          console.log("Transcript Reducer, new final transcript block added", action.payload.block);
          transcript.addFinalBlock(action.payload);
          return copyState;
       case 'transcript/update_in_progress_block':
+         // Modify in-progress block of the transcript
          console.log("Transcript Reducer, in-progress block updated", action.payload.block);
          transcript.inProgressBlock = action.payload;
          return copyState;

--- a/src/react-redux&middleware/redux/types/TranscriptTypes.tsx
+++ b/src/react-redux&middleware/redux/types/TranscriptTypes.tsx
@@ -32,11 +32,17 @@ export class TranscriptBlock {
 
 /**
  * A transcript of a single speaker's speech, containing a list of finalized transcript blocks
- * and a single in-progress transcript block.
+ * and a single in-progress transcript block, in chronological order.
  * 
- * The final blocks can only be appended to, as finalized blocks cannot be "unfinalized". However,
- * the in-progress block can be modified freely, allowing revising recent transcript based on new information
- * (e.g. as done by Azure recognizer)
+ * We assume that once a block is finalized it cannot be un-finalized, but the in-progress block
+ * can be modified freely. This means that the final block list is append-only, whereas the in-progress
+ * block is public.
+ * 
+ * Furthermore, we assume that a recognizer finalizes the in-progress block before it stops -
+ * thus no transcript is lost when a different recognizer takes over the in-progress block.
+ * 
+ * This protocol allowing aggregating transcript from multiple APIs, while still allowing revising
+ * recent transcript based on new information (e.g. as done by Azure recognizer)
  */
 export class Transcript {
    /**

--- a/src/react-redux&middleware/redux/types/TranscriptTypes.tsx
+++ b/src/react-redux&middleware/redux/types/TranscriptTypes.tsx
@@ -1,4 +1,5 @@
-import { STATUS, API } from './apiEnums';
+import { InvalidOperationError } from 'microsoft-cognitiveservices-speech-sdk/distrib/lib/src/common/Error';
+import { STATUS, API, ApiType } from './apiEnums';
 import sdk from 'microsoft-cognitiveservices-speech-sdk';
 
 
@@ -19,20 +20,78 @@ export type Sentence = {
 // TODO: Consider adding Paragraph, which has an AI-generated summary
 
 /**
- * Used in sttRenderer.tsx 
- * 
- * The full displayed transcript is always previousTranscript + currentTranscript
- * 
- * SpeakerID at index i has fullTranscript at index i; array length = num speakers
+ * A segment of a transcript, representing a continuous segment of speech
  */
-export type Transcript = {
-   speakerNum: number;
-   maxSpeaker: number;
-   previousTranscript: string[];
-   currentTranscript: string[];
-   speakerIDs: string[];
+export class TranscriptBlock {
+   /**
+    * Transcript text
+    */
+   text: string = "";
+   // TODO: add more fields - confidence, which API recognized this block, etc
 }
 
+/**
+ * A transcript of a single speaker's speech, containing a list of finalized transcript blocks
+ * and a single in-progress transcript block.
+ * 
+ * The final blocks can only be appended to, as finalized blocks cannot be "unfinalized". However,
+ * the in-progress block can be modified freely, allowing revising recent transcript based on new information
+ * (e.g. as done by Azure recognizer)
+ */
+export class Transcript {
+   /**
+    * ID of the speaker that this transcript corresponds to
+    */
+   speakerIDs: string = "Unnamed";
+   
+   /**
+    * Finalized transcript blocks in chronological order. Can only be appended to at the end.
+    */
+   _finalBlocks: Array<TranscriptBlock> = [];
+   set finalBlocks(value) {
+      throw new Error("Final blocks cannot be directly modified!")
+   }
+   get finalBlocks() {
+      return this._finalBlocks
+   }
+
+   /**
+    * In progress transcript block
+    */
+   inProgressBlock: TranscriptBlock = new TranscriptBlock();
+
+   /**
+    * Append a new transcript block to the end of the final list
+    * @param block Transcript block to be appended
+    */
+   addFinalBlock(toAdd: TranscriptBlock): void {
+      this.finalBlocks.push(toAdd);
+   }
+
+   /**
+    * Returns the full text of the transcript.
+    */
+   toString(): string {
+      // Join all final blocks followed by in-progress block
+      return this.finalBlocks.map((block) => block.text).join(' ') + ' ' + this.inProgressBlock.text 
+   }
+}
+
+/**
+ * A collection of single-speaker transcripts, used to transcribe multi-speaker speech.
+ * 
+ * Currently only supports one speaker at transcripts[0]
+ */
+export class MultiSpeakerTranscript {
+   /**
+    * Maximum number of speakers this transcript expects
+    */
+   maxSpeakers: number = 4;
+   /**
+    * A list of single-speaker transcripts
+    */
+   transcripts: Array<Transcript> = [new Transcript];
+}
 
 
 // TODO: deprecate Speaker, OldTranscript, and AllSpeakerTranscript

--- a/src/react-redux&middleware/redux/typesImports.tsx
+++ b/src/react-redux&middleware/redux/typesImports.tsx
@@ -19,7 +19,6 @@ export type {
    SRecognition,
    Word,
    Sentence,
-   Transcript,
 
    // alias
    ScribeRecognizer,


### PR DESCRIPTION
Solved the API compatibility issue with the Recognizer interface. Now both Web Speech and Azure implement the interface and expose the same few public methods to be used by useRecognition.

Further, refactored transcript stream to a list of finalized transcript blocks and a single in-progress transcript block to allow all APIs to yield the same transcript updates. Unfortunately this meant changing Tiger's data structure quite drastically - please review this part if you could!