### PR TITLE
Tiny update on landing page redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,14 +1,17 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta http-equiv="Refresh" content="0; url=https://scribear.github.io/v/index.html" />
-    <meta http-equiv="Refresh" content="0; url=v/index.html" />
-
-    
+    <script type="text/javascript">
+      // Redirect as soon as the script runs
+      window.location.href = "https://scribear.github.io/v/index.html";
+    </script>
+  </head>
   </head>
   <body>
     <p>Please follow <a href="https://scribear.github.io/v/index.html">Choose version</a>.</p>
     <p>Please follow <a href="v/index.html">Choose version</a>.</p>
-
+    <noscript>
+      <meta http-equiv="refresh" content="0; url=https://scribear.github.io/v/index.html">
+    </noscript>
   </body>
 </html>


### PR DESCRIPTION
One tiny problem. When I go to https://scribear.illinois.edu/ I see a different page for half a second before it redirects to the landing page. I think the problem here is that in our current `index.html`, we are doing a "refresh" instead of a straightforward redirect.

```html
<!DOCTYPE html>
<html>
  <head>
    <meta http-equiv="Refresh" content="0; url=https://scribear.github.io/v/index.html" />
    <meta http-equiv="Refresh" content="0; url=v/index.html" />

    
  </head>
  <body>
    <p>Please follow <a href="https://scribear.github.io/v/index.html">Choose version</a>.</p>
    <p>Please follow <a href="v/index.html">Choose version</a>.</p>

  </body>
</html>
```
So I changed this into a Javascript redirect, which works on my laptop:
```javascript
window.location.href = "https://scribear.github.io/v/index.html";
```
