### PR TITLE
Frontend select model

### DIFF
--- a/src/components/api/recogComponent.tsx
+++ b/src/components/api/recogComponent.tsx
@@ -17,6 +17,7 @@ import { STTRenderer } from '../sttRenderer';
 import { PlaybackStatus, StreamTextStatus } from '../../react-redux&middleware/redux/types/apiTypes';
 import Swal from 'sweetalert2';
 import { useRecognition } from './returnAPI';
+import { selectSelectedModel } from '../../react-redux&middleware/redux/reducers/modelSelectionReducers';
 
 export const RecogComponent: React.FC = (props) => {
 
@@ -82,9 +83,10 @@ export const RecogComponent: React.FC = (props) => {
    const sRecog = useSelector((state: RootState) => {
       return state.SRecognitionReducer as SRecognition;
    })
+   const selectedModelOption = useSelector(selectSelectedModel);
 
    // if else for whisper transcript, apiStatus for 4=whisper and control status for listening
-   const transcript = useRecognition(sRecog, apiStatus, controlStatus, azureStatus, streamTextStatus, scribearServerStatus, playbackStatus);
+   const transcript = useRecognition(sRecog, apiStatus, controlStatus, azureStatus, streamTextStatus, scribearServerStatus, selectedModelOption, playbackStatus);
    // console.log("Recog component received new transcript: ", transcript)
    return STTRenderer(transcript);
 };

--- a/src/components/api/scribearServer/scribearRecognizer.tsx
+++ b/src/components/api/scribearServer/scribearRecognizer.tsx
@@ -83,21 +83,23 @@ export class ScribearRecognizer implements Recognizer {
             socket.send(JSON.stringify({
                 api_key: this.scribearServerStatus.scribearServerKey,
                 sourceToken: this.scribearServerStatus.scribearServerKey,
-                sessionToken: this.scribearServerStatus.scribearServerKey
+                sessionToken: this.scribearServerStatus.scribearServerSessionToken,
             }));
         }
 
         socket.onmessage = (event) => {
-            const message = JSON.parse(event.data);
-            console.log(message);
-            if (message['error'] || !Array.isArray(message)) return;
+            if (!this.scribearServerStatus.scribearServerSessionToken) {
+                const message = JSON.parse(event.data);
+                console.log(message);
+                if (message['error'] || !Array.isArray(message)) return;
 
-            store.dispatch(setModelOptions(message));
+                store.dispatch(setModelOptions(message));
 
-            if (this.selectedModelOption) {
-                socket.send(JSON.stringify(this.selectedModelOption));
-            } else {
-                return;
+                if (this.selectedModelOption) {
+                    socket.send(JSON.stringify(this.selectedModelOption));
+                } else {
+                    return;
+                }
             }
 
             this.socket = socket;

--- a/src/components/api/scribearServer/scribearRecognizer.tsx
+++ b/src/components/api/scribearServer/scribearRecognizer.tsx
@@ -82,18 +82,21 @@ export class ScribearRecognizer implements Recognizer {
         socket.onopen = (event) => {
             socket.send(JSON.stringify({
                 api_key: this.scribearServerStatus.scribearServerKey,
-                sourceToken: this.scribearServerStatus.scribearServerKey
+                sourceToken: this.scribearServerStatus.scribearServerKey,
+                sessionToken: this.scribearServerStatus.scribearServerKey
             }));
         }
 
         socket.onmessage = (event) => {
-            const options = JSON.parse(event.data);
-            store.dispatch(setModelOptions(options));
+            const message = JSON.parse(event.data);
+            console.log(message);
+            if (message['error'] || !Array.isArray(message)) return;
+
+            store.dispatch(setModelOptions(message));
 
             if (this.selectedModelOption) {
                 socket.send(JSON.stringify(this.selectedModelOption));
             } else {
-                store.dispatch(setSelectedModel(options[0]));
                 return;
             }
 

--- a/src/components/navbars/sidebar/model/menu.tsx
+++ b/src/components/navbars/sidebar/model/menu.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import { List, ListItemText, Collapse, ListItem, MemoryIcon, Autocomplete, TextField, Tooltip } from '../../../../muiImports';
+import { useSelector } from 'react-redux';
+import type { RootState } from '../../../../store';
+import { API, type ApiStatus } from '../../../../react-redux&middleware/redux/typesImports';
+import { useDispatch } from 'react-redux';
+import { selectModelOptions, selectSelectedModel, setSelectedModel } from '../../../../react-redux&middleware/redux/reducers/modelSelectionReducers';
+
+export default function ModelMenu(props) {
+  const dispatch = useDispatch();
+  const APIStatus = useSelector((state: RootState) => {
+    return state.APIStatusReducer as ApiStatus;
+  });
+  const modelOptions = useSelector(selectModelOptions);
+  const selected = useSelector(selectSelectedModel);
+  const modelSelectEnable = APIStatus.currentApi !== API.SCRIBEAR_SERVER;
+
+  return (
+    <div>
+      {props.listItemHeader("Model", "model", MemoryIcon)}
+
+      <Collapse in={props.open} timeout="auto" unmountOnExit>
+        <List component="div" disablePadding>
+          <ListItem sx={{ pl: 4 }}>
+            <ListItemText primary="Select Model" />
+          </ListItem>
+
+          <ListItem sx={{ pl: 4 }}>
+            <Autocomplete
+              disabled={modelSelectEnable}
+              sx={{ width: 300 }}
+              disablePortal
+              options={modelOptions}
+              onChange={(_, val) => {
+                dispatch(setSelectedModel(val))
+              }}
+              defaultValue={selected}
+              getOptionLabel={(v) => v.display_name}
+              isOptionEqualToValue={(a, b) => a.model_key === b.model_key}
+              renderInput={(params) => <TextField {...params} />}
+              renderOption={(props, option) => {
+                return <Tooltip key={props.key} title={option.description} placement='right'>
+                  <ListItem {...props}>
+                    {option.display_name}
+                  </ListItem>
+                </Tooltip>
+              }}
+            />
+          </ListItem>
+
+        </List>
+      </Collapse>
+    </div>
+  );
+}

--- a/src/components/navbars/sidebar/sidebar.tsx
+++ b/src/components/navbars/sidebar/sidebar.tsx
@@ -6,10 +6,12 @@ import LangMenu from './language/menu';
 import PhraseMenu from './phrase/menu';
 import VisualizationMenu from './audioVisBar/menu';
 import CaptionsMenu from './captions/menu';
+import ModelMenu from './model/menu';
 
 
 export default function SideBar(props) {
   const [state, setState] = React.useState({
+    model: false,
     display: false,
     lang: true,
     visualization: false,
@@ -48,7 +50,10 @@ export default function SideBar(props) {
       <List sx={{ width: { xs: '100vw', sm: '50vw', md: '40vw', lg: '30vw' }, bgcolor: 'background.paper' }} component="nav" aria-labelledby="nested-list-subheader" >
         <LangMenu open={state.lang} isRecording={props.isRecording} listItemHeader={listItemHeader} />
         <Divider/>
-        
+
+        <ModelMenu open={state.model} listItemHeader={listItemHeader} />
+        <Divider/>
+
         <DisplayMenu open={state.display} listItemHeader={listItemHeader} />
         <Divider/>
         

--- a/src/components/navbars/topbar/api/ScribearServerSettings.tsx
+++ b/src/components/navbars/topbar/api/ScribearServerSettings.tsx
@@ -104,10 +104,10 @@ export default function ScribearServerSettings(props) {
                         onChange={updateReact}
                         value={scribearServerStatusBuf.scribearServerKey}
                         id="scribearServerKey"
-                        label="ScribeAR Server API Key / Source Token"
+                        label="ScribeAR Server API Key / Token"
                         variant="outlined"
                         inputProps={{
-                           placeholder: 'Enter ScribeAR API Key or Source Token',
+                           placeholder: 'Enter ScribeAR API Key or Token',
                         }}
                         style={{ width: '100%' }}
                      />

--- a/src/components/navbars/topbar/api/ScribearServerSettings.tsx
+++ b/src/components/navbars/topbar/api/ScribearServerSettings.tsx
@@ -88,6 +88,29 @@ export default function ScribearServerSettings(props) {
                         }}
                         style={{ width: '100%' }}
                      />
+                     </Box>
+               </ListItem>
+               <ListItem sx={{ pl: 4 }}>
+                  <Box
+                     component="form"
+                     sx={{ width: '50vw',
+                           '& > :not(style)': { pr: '1vw', width: '15vw' },
+                     }}
+                     noValidate
+                     autoComplete="off"
+                     onSubmit={closePopup} // Prevent default submission behavior of refreshing page
+                  >
+                     <TextField
+                        onChange={updateReact}
+                        value={scribearServerStatusBuf.scribearServerKey}
+                        id="scribearServerKey"
+                        label="ScribeAR Server API Key / Source Token"
+                        variant="outlined"
+                        inputProps={{
+                           placeholder: 'Enter ScribeAR API Key or Source Token',
+                        }}
+                        style={{ width: '100%' }}
+                     />
                   </Box>
                </ListItem>
               

--- a/src/components/navbars/topbar/apiDropdown.tsx
+++ b/src/components/navbars/topbar/apiDropdown.tsx
@@ -40,11 +40,12 @@ export default function ApiDropdown(props) {
 
   // Automatically use scribear server as sink when in student mode or as sourcesink if in kiosk mode
   useEffect(() => {
-    function switchToScribeARServer(scribearServerAddress: string, token: string) {
+    function switchToScribeARServer(scribearServerAddress: string, token: string | undefined) {
       // Set new scribear server address
       let copyScribearServerStatus = Object.assign({}, scribearServerStatus);
       copyScribearServerStatus.scribearServerAddress = scribearServerAddress
-      copyScribearServerStatus.scribearServerKey = token
+      copyScribearServerStatus.scribearServerKey = sourceToken as string;
+      copyScribearServerStatus.scribearServerSessionToken = token
 
       dispatch({ type: 'CHANGE_SCRIBEAR_SERVER_ADDRESS', payload: copyScribearServerStatus });
 
@@ -62,7 +63,7 @@ export default function ApiDropdown(props) {
     }
 
     if (mode === 'kiosk') {
-      switchToScribeARServer(`ws://${kioskServerAddress}/sourcesink`, sourceToken as string);
+      switchToScribeARServer(`ws://${kioskServerAddress}/sourcesink`, undefined);
     } else if (mode === 'student') {
       console.log("Sending startSession POST with accessToken:", accessToken);
       fetch(`http://${serverAddress}/startSession`, {
@@ -76,7 +77,7 @@ export default function ApiDropdown(props) {
         .then(data => {
           console.log('Session token:', data.sessionToken);
 
-          const scribearServerAddress = `ws://${serverAddress}/sink?sessionToken=${encodeURIComponent(data.sessionToken)}`;
+          const scribearServerAddress = `ws://${serverAddress}/sink`;
 
           switchToScribeARServer(scribearServerAddress, data.sessionToken);
         })

--- a/src/components/navbars/topbar/apiDropdown.tsx
+++ b/src/components/navbars/topbar/apiDropdown.tsx
@@ -14,11 +14,11 @@ import { useDispatch, useSelector } from "react-redux";
 import { ScribearServerStatus } from '../../../react-redux&middleware/redux/typesImports';
 
 const currTheme = createTheme({
-    palette: {
-        primary: {
-            main: '#ffffff'
-        }
-    },
+  palette: {
+    primary: {
+      main: '#ffffff'
+    }
+  },
 });
 
 export default function ApiDropdown(props) {
@@ -40,28 +40,29 @@ export default function ApiDropdown(props) {
 
   // Automatically use scribear server as sink when in student mode or as sourcesink if in kiosk mode
   useEffect(() => {
-    function switchToScribeARServer(scribearServerAddress: string) {
+    function switchToScribeARServer(scribearServerAddress: string, token: string) {
       // Set new scribear server address
       let copyScribearServerStatus = Object.assign({}, scribearServerStatus);
       copyScribearServerStatus.scribearServerAddress = scribearServerAddress
-  
-      dispatch({type: 'CHANGE_SCRIBEAR_SERVER_ADDRESS', payload: {scribearServerAddress}});
-      
-    // Switch to scribear server
-    let copyStatus = Object.assign({}, apiStatus);
-    copyStatus.currentApi = API.SCRIBEAR_SERVER;
-    copyStatus.webspeechStatus = STATUS.AVAILABLE;
-    copyStatus.azureConvoStatus = STATUS.AVAILABLE;
-    copyStatus.whisperStatus = STATUS.AVAILABLE;
-    copyStatus.streamTextStatus = STATUS.AVAILABLE;
-    copyStatus.playbackStatus = STATUS.AVAILABLE;
-    copyStatus.scribearServerStatus = STATUS.TRANSCRIBING;
+      copyScribearServerStatus.scribearServerKey = token
 
-    dispatch({type: 'CHANGE_API_STATUS', payload: copyStatus});
-  }
+      dispatch({ type: 'CHANGE_SCRIBEAR_SERVER_ADDRESS', payload: copyScribearServerStatus });
+
+      // Switch to scribear server
+      let copyStatus = Object.assign({}, apiStatus);
+      copyStatus.currentApi = API.SCRIBEAR_SERVER;
+      copyStatus.webspeechStatus = STATUS.AVAILABLE;
+      copyStatus.azureConvoStatus = STATUS.AVAILABLE;
+      copyStatus.whisperStatus = STATUS.AVAILABLE;
+      copyStatus.streamTextStatus = STATUS.AVAILABLE;
+      copyStatus.playbackStatus = STATUS.AVAILABLE;
+      copyStatus.scribearServerStatus = STATUS.TRANSCRIBING;
+
+      dispatch({ type: 'CHANGE_API_STATUS', payload: copyStatus });
+    }
 
     if (mode === 'kiosk') {
-      switchToScribeARServer(`ws://${kioskServerAddress}/sourcesink?sourceToken=${sourceToken}`);
+      switchToScribeARServer(`ws://${kioskServerAddress}/sourcesink`, sourceToken as string);
     } else if (mode === 'student') {
       console.log("Sending startSession POST with accessToken:", accessToken);
       fetch(`http://${serverAddress}/startSession`, {
@@ -77,7 +78,7 @@ export default function ApiDropdown(props) {
 
           const scribearServerAddress = `ws://${serverAddress}/sink?sessionToken=${encodeURIComponent(data.sessionToken)}`;
 
-          switchToScribeARServer(scribearServerAddress);
+          switchToScribeARServer(scribearServerAddress, data.sessionToken);
         })
         .catch(error => {
           console.error('Error starting session:', error);
@@ -97,7 +98,7 @@ export default function ApiDropdown(props) {
   // Make this a dropdown menu with the current api as the menu title
   return (
     <React.Fragment>
-      <Box sx={{ display: 'flex', alignItems: 'center', textAlign: 'center'}}>
+      <Box sx={{ display: 'flex', alignItems: 'center', textAlign: 'center' }}>
         {props.apiDisplayName}
         <Tooltip title="API choice">
           <IconButton onClick={handleClick}>
@@ -141,7 +142,7 @@ export default function ApiDropdown(props) {
         transformOrigin={{ horizontal: 'center', vertical: 'top' }}
         anchorOrigin={{ horizontal: 'center', vertical: 'bottom' }}
       >
-        <PickApi/>
+        <PickApi />
       </Menu>
     </React.Fragment>
   );

--- a/src/muiImports.tsx
+++ b/src/muiImports.tsx
@@ -54,7 +54,7 @@ import SubtitlesIcon from '@mui/icons-material/Subtitles';
 import FormatColorTextIcon from '@mui/icons-material/FormatColorText';
 import Autocomplete from '@mui/material/Autocomplete';
 import { Switch } from '@mui/material';
-
+import MemoryIcon from '@mui/icons-material/Memory';
 export {
     createTheme,
     Autocomplete,
@@ -114,4 +114,5 @@ export {
     FormatColorTextIcon,
     ArchitectureIcon,
     Switch,
+    MemoryIcon
 }

--- a/src/react-redux&middleware/redux/reducers/apiReducers.tsx
+++ b/src/react-redux&middleware/redux/reducers/apiReducers.tsx
@@ -47,7 +47,8 @@ const initialPlaybackStatus: PlaybackStatus = {
 }
 
 const initialScribearServerState: ScribearServerStatus = {
-  scribearServerAddress: 'ws://localhost:1234'
+  scribearServerAddress: 'ws://localhost:8080/sourcesink',
+  scribearServerKey: '',
 }
 
 const saveLocally = (varName: string, value: any) => {

--- a/src/react-redux&middleware/redux/reducers/apiReducers.tsx
+++ b/src/react-redux&middleware/redux/reducers/apiReducers.tsx
@@ -1,6 +1,6 @@
 import { API, STATUS } from '../types/apiEnums';
 import { ApiStatus, AzureStatus, PhraseList, PhraseListStatus } from "../typesImports";
-import { StreamTextStatus, WhisperStatus,ScribearServerStatus, PlaybackStatus } from "../types/apiTypes";
+import { StreamTextStatus, WhisperStatus, ScribearServerStatus, PlaybackStatus } from "../types/apiTypes";
 
 const initialAPIStatusState: ApiStatus = {
   currentApi: API.WEBSPEECH,
@@ -9,8 +9,8 @@ const initialAPIStatusState: ApiStatus = {
   azureConvoStatus: STATUS.AVAILABLE,
   whisperStatus: STATUS.AVAILABLE,
   streamTextStatus: STATUS.AVAILABLE,
-  scribearServerStatus : STATUS.AVAILABLE,
-  playbackStatus : STATUS.AVAILABLE
+  scribearServerStatus: STATUS.AVAILABLE,
+  playbackStatus: STATUS.AVAILABLE
 }
 
 const initialPhraseList: PhraseList = {
@@ -49,6 +49,7 @@ const initialPlaybackStatus: PlaybackStatus = {
 const initialScribearServerState: ScribearServerStatus = {
   scribearServerAddress: 'ws://localhost:8080/sourcesink',
   scribearServerKey: '',
+  scribearServerSessionToken: undefined,
 }
 
 const saveLocally = (varName: string, value: any) => {
@@ -89,7 +90,7 @@ const getLocalState = (name: string) => {
   } else if (name === "scribearServerStatus") {
     return saveLocally("scribearServerStatus", initialScribearServerState);
   }
-  return {} ;
+  return {};
 };
 
 export const APIStatusReducer = (state = getLocalState("apiStatus") as ApiStatus, action) => {
@@ -106,15 +107,17 @@ export const APIStatusReducer = (state = getLocalState("apiStatus") as ApiStatus
   }
 }
 
-export const AzureReducer = (state = getLocalState("azureStatus") , action) => {
+export const AzureReducer = (state = getLocalState("azureStatus"), action) => {
   switch (action.type) {
     case 'CHANGE_AZURE_LOGIN':
       return { ...state, ...action.payload };
     case 'CHANGE_AZURE_STATUS':
       return { ...state, ...action.payload };
     case 'CHANGE_LIST':
-      return { ...state, 
-               phrases: action.payload }
+      return {
+        ...state,
+        phrases: action.payload
+      }
     default:
       return state;
   }
@@ -125,10 +128,10 @@ export const WhisperReducer = (state = getLocalState("whisperStatus"), action) =
 }
 
 export const StreamTextReducer = (state = getLocalState("streamTextStatus"), action) => {
-  switch(action.type) {
+  switch (action.type) {
     case 'CHANGE_STREAMTEXT_STATUS':
       return { ...state, ...action.payload };
-      
+
     default:
       return state;
   }
@@ -136,22 +139,22 @@ export const StreamTextReducer = (state = getLocalState("streamTextStatus"), act
 export const ScribearServerReducer = (state = getLocalState("scribearServerStatus"), action) => {
   switch (action.type) {
     case 'CHANGE_SCRIBEAR_SERVER_ADDRESS':
-      const newState =  { ...state, ...action.payload };
+      const newState = { ...state, ...action.payload };
       saveLocally('scribearServerStatus', newState);
       return newState;
-    
+
     default:
       return state;
   }
 }
 
 export const PlaybackReducer = (state = getLocalState("playbackStatus"), action) => {
-  
-  switch(action.type) {
+
+  switch (action.type) {
     case 'CHANGE_PLAYBACK_STATUS':
       console.log("PlaybackReducer CHANGE_PLAYBACK_STATUS: status & action", state, action);
       return { ...state, ...action.payload };
-      
+
     default:
       return state;
   }
@@ -196,13 +199,17 @@ export const PhraseListReducer = (state = initialPhraseListState, action) => {
           ...state,
         }
       }
-    case 'EDIT_PHRASE_LIST':     
-      return { ...state,
-               currentPhraseList: action.payload}
+    case 'EDIT_PHRASE_LIST':
+      return {
+        ...state,
+        currentPhraseList: action.payload
+      }
     // existing cases
-    case 'SET_FILE_CONTENT':     
-      return { ...state,
-               fileContent: action.payload}
+    case 'SET_FILE_CONTENT':
+      return {
+        ...state,
+        fileContent: action.payload
+      }
     case 'SET_PHRASE_OPTION_TO_CUSTOM': {
       const newPhraseListMap = new Map(state.phraseListMap);
       const phraseData: PhraseList = newPhraseListMap.get(action.payload.phraseName) || {

--- a/src/react-redux&middleware/redux/reducers/modelSelectionReducers.tsx
+++ b/src/react-redux&middleware/redux/reducers/modelSelectionReducers.tsx
@@ -3,21 +3,40 @@ import type { RootState } from '../typesImports'
 
 const initialState: ModelSelection = { options: [], selected: null }
 
+
+const saveLocally = (key: string, value: any) => {
+  localStorage.setItem(key, JSON.stringify(value));
+}
+const getLocalState = (key: string) => {
+  const localState = localStorage.getItem(key);
+
+  if (localState) {
+    return Object.assign(initialState, JSON.parse(localState));
+  }
+
+  return initialState;
+}
+
 export const ModelSelectionReducer = (
-  state = initialState,
+  state = getLocalState('modelSelection'),
   action
 ) => {
+  let newState;
   switch (action.type) {
     case 'SET_MODEL_OPTIONS':
-      return {
+      newState = {
         ...state,
         options: action.payload as ModelOptions
       }
+      saveLocally('modelSelection', newState)
+      return newState;
     case 'SET_SELECTED_MODEL':
-      return {
+      newState = {
         ...state,
         selected: action.payload as SelectedOption
       }
+      saveLocally('modelSelection', newState)
+      return newState;
     default:
       return state
   }

--- a/src/react-redux&middleware/redux/reducers/modelSelectionReducers.tsx
+++ b/src/react-redux&middleware/redux/reducers/modelSelectionReducers.tsx
@@ -1,0 +1,33 @@
+import type { ModelOptions, ModelSelection, SelectedOption } from '../types/modelSelection'
+import type { RootState } from '../typesImports'
+
+const initialState: ModelSelection = { options: [], selected: null }
+
+export const ModelSelectionReducer = (
+  state = initialState,
+  action
+) => {
+  switch (action.type) {
+    case 'SET_MODEL_OPTIONS':
+      return {
+        ...state,
+        options: action.payload as ModelOptions
+      }
+    case 'SET_SELECTED_MODEL':
+      return {
+        ...state,
+        selected: action.payload as SelectedOption
+      }
+    default:
+      return state
+  }
+}
+
+export const selectModelOptions = (state: RootState) => state.ModelSelectionReducer.options;
+export const setModelOptions = (options: ModelOptions) => {
+  return { type: 'SET_MODEL_OPTIONS', payload: options }
+}
+export const selectSelectedModel = (state: RootState) => state.ModelSelectionReducer.selected;
+export function setSelectedModel(selected: SelectedOption) {
+  return { type: 'SET_SELECTED_MODEL', payload: selected }
+}

--- a/src/react-redux&middleware/redux/types/apiTypes.tsx
+++ b/src/react-redux&middleware/redux/types/apiTypes.tsx
@@ -65,6 +65,7 @@ export type PlaybackStatus = {
 }
 
 export type ScribearServerStatus = {
-   scribearServerAddress : string
+   scribearServerAddress: string
+   scribearServerKey: string
    // Many IP (or hostname) and port in the future
 }

--- a/src/react-redux&middleware/redux/types/apiTypes.tsx
+++ b/src/react-redux&middleware/redux/types/apiTypes.tsx
@@ -67,5 +67,6 @@ export type PlaybackStatus = {
 export type ScribearServerStatus = {
    scribearServerAddress: string
    scribearServerKey: string
+   scribearServerSessionToken: string | undefined
    // Many IP (or hostname) and port in the future
 }

--- a/src/react-redux&middleware/redux/types/modelSelection.tsx
+++ b/src/react-redux&middleware/redux/types/modelSelection.tsx
@@ -1,0 +1,18 @@
+export type ModelOptions = Array<{
+  model_key: string;
+  display_name: string;
+  description: string;
+  available_features: string;
+}>;
+
+export type SelectedOption = {
+  model_key: string;
+  display_name: string;
+  description: string;
+  available_features: string;
+} | null;
+
+export type ModelSelection = {
+  options: ModelOptions,
+  selected: SelectedOption
+};

--- a/src/react-redux&middleware/redux/typesImports.tsx
+++ b/src/react-redux&middleware/redux/typesImports.tsx
@@ -1,12 +1,15 @@
 import { API, ApiType, STATUS, StatusType } from './types/apiEnums';
-import { ApiStatus, AzureStatus, PhraseList, PhraseListStatus, 
-   StreamTextStatus, WhisperStatus, ScribearServerStatus, PlaybackStatus } from './types/apiTypes';
+import {
+   ApiStatus, AzureStatus, PhraseList, PhraseListStatus,
+   StreamTextStatus, WhisperStatus, ScribearServerStatus, PlaybackStatus
+} from './types/apiTypes';
 import { ControlStatus, LanguageList } from "./types/controlStatus";
 import { SRecognition, ScribeHandler, ScribeRecognizer } from "./types/sRecognition";
 import { Sentence, Word } from "./types/TranscriptTypes";
 
 import { DisplayStatus } from "./types/displayStatus";
 import { MainStream } from "./types/bucketStreamTypes";
+import type { ModelSelection } from './types/modelSelection';
 
 export type {
    ApiStatus,
@@ -44,9 +47,10 @@ export type RootState = {
    AzureReducer: AzureStatus
    ControlReducer: ControlStatus
    PhraseListReducer: PhraseListStatus
-   initialStreams : MainStream
+   initialStreams: MainStream
    WhisperReducer: WhisperStatus
    StreamTextReducer: StreamTextStatus
-   ScribearServerReducer : ScribearServerStatus
-   PlaybackReducer : PlaybackStatus
+   ScribearServerReducer: ScribearServerStatus
+   PlaybackReducer: PlaybackStatus,
+   ModelSelectionReducer: ModelSelection
 }

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -1,5 +1,7 @@
-import { APIStatusReducer, AzureReducer, PhraseListReducer, StreamTextReducer,
-    WhisperReducer,ScribearServerReducer,PlaybackReducer } from './react-redux&middleware/redux/reducers/apiReducers'
+import {
+   APIStatusReducer, AzureReducer, PhraseListReducer, StreamTextReducer,
+   WhisperReducer, ScribearServerReducer, PlaybackReducer
+} from './react-redux&middleware/redux/reducers/apiReducers'
 import { combineReducers } from 'redux'
 
 import { BucketStreamReducer } from './react-redux&middleware/redux/reducers/bucketStreamReducers'
@@ -10,6 +12,7 @@ import { TranscriptReducer } from './react-redux&middleware/redux/reducers/trans
 
 import { configureStore } from '@reduxjs/toolkit'
 import thunkMiddleware from 'redux-thunk'
+import { ModelSelectionReducer } from './react-redux&middleware/redux/reducers/modelSelectionReducers'
 
 const rootReducer = combineReducers({
    DisplayReducer,
@@ -23,7 +26,8 @@ const rootReducer = combineReducers({
    TranscriptReducer,
    SRecognitionReducer,
    ScribearServerReducer,
-   PlaybackReducer
+   PlaybackReducer,
+   ModelSelectionReducer
 })
 
 // export const store = createStore(rootReducer)


### PR DESCRIPTION
Provides a way to select the model/config for whisper service on the frontend. 

Makes  progress on #207  and #208 since this implements a mechanism for the backend to report supported features to the frontend and for the frontend to send configuration to the backend.
